### PR TITLE
Fix incorrect use of S3Fs's API for file deletion

### DIFF
--- a/kbatch_papermill/_papermill.py
+++ b/kbatch_papermill/_papermill.py
@@ -154,6 +154,6 @@ def kbatch_papermill(
     except Exception:
         # cleanup s3 if it fails
         s3 = s3fs.S3FileSystem(anon=False)
-        s3.remove(s3_code_url)
+        s3.rm(s3_code_url)
         raise
     return kubernetes_job["metadata"]["name"]


### PR DESCRIPTION
In case of job failure, the file on the S3 bucket is currently removed with `s3fs.remove(...)` instead of `s3fs.rm(...)`, which raises an error.