### PR TITLE
Documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,32 @@
+name: documentation
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install -r docs/requirements.txt
+          pip install -e .
+          cp README.md docs/readme.md
+      - name: Sphinx build
+        run: |
+          sphinx-build docs _build
+      # we check that the push is done on a specific branch here in order to verify that the build succeeds
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/
+          force_orphan: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,8 @@ jobs:
           pip install -e . -r docs/requirements.txt
       - name: Sphinx build
         run: |
-          sphinx-build docs _build
+          cd docs
+          sphinx-build . ../_build
       # we check that the push is done on a specific branch here in order to verify that the build succeeds
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,12 +18,11 @@ jobs:
           pip install -e . -r docs/requirements.txt
       - name: Sphinx build
         run: |
-          cd docs
-          sphinx-build . ../_build
+          sphinx-build docs _build --fail-on-warning --keep-going
       # we check that the push is done on a specific branch here in order to verify that the build succeeds
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/documentation' }}
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,11 +19,11 @@ jobs:
       - name: Sphinx build
         run: |
           sphinx-build docs _build --fail-on-warning --keep-going
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        with:
-          publish_branch: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _build/
-          force_orphan: true
+      # - name: Deploy to GitHub Pages
+      #   uses: peaceiris/actions-gh-pages@v3
+      #   if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      #   with:
+      #     publish_branch: gh-pages
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     publish_dir: _build/
+      #     force_orphan: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,10 +19,9 @@ jobs:
       - name: Sphinx build
         run: |
           sphinx-build docs _build --fail-on-warning --keep-going
-      # we check that the push is done on a specific branch here in order to verify that the build succeeds
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/documentation' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,9 +15,7 @@ jobs:
           python-version: '3.10'
       - name: Install dependencies
         run: |
-          pip install -r docs/requirements.txt
-          pip install -e .
-          cp README.md docs/readme.md
+          pip install -e . -r docs/requirements.txt
       - name: Sphinx build
         run: |
           sphinx-build docs _build

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .

--- a/README.md
+++ b/README.md
@@ -1,20 +1,17 @@
 # kbatch-papermill
 
-run notebooks with [papermill] on kubernetes via [kbatch], currently designed for [Destination-Earth GFTS](https://github.com/destination-earth/DestinE_ESA_GFTS).
+Currently designed for [Destination-Earth GFTS](https://github.com/destination-earth/DestinE_ESA_GFTS), it runs notebooks with [papermill] on Kubernetes via [kbatch].
+It does not currently target general use because the following assumptions, specific to GFTS deployments, are made:
 
-Not currently targeting general use because we're making the following assumptions specific to the GFTS deployment:
+1. Default AWS credentials are set up via environment variables, and work.
+2. Jobs should always run with the same $JUPYTER_IMAGE as the submitting environment.
+3. $JUPYTER_IMAGE has `papermill`.
+4. We have read/write access to S3 for _both_ the code input directory and the output directory (completed job results).
 
-1. default AWS credentials are set up via environment variables, and work
-2. jobs should always run with the same $JUPYTER_IMAGE as the submitting environment
-3. $JUPYTER_IMAGE has papermill
-4. we have read/write access to s3 for both the code input directory and the completed job results
+Note that we do not use the [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) approach to pass the code directory, because of the size limit on config maps.
+So we essentially replicate the code directory functionality of kbatch, but store in S3 instead.
 
-The ConfigMap approach to passing the code directory doesn't work great for us due to the size limit on config maps.
-So we essentially replicate the code directory functionality of kbatch,
-but store in s3 instead.
-
-Some generic functionality is here to make a nicer Python API for kbatch,
-which should perhaps be upstreamed. See `_kbatch.py` for most of that.
+We also add some generic functionality to make a nicer Python API for kbatch, which should perhaps be upstreamed. See `_kbatch.py` for most of that.
 
 [papermill]: https://papermill.readthedocs.io
 [kbatch]: https://kbatch.readthedocs.io

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= --fail-on-warning --keep-going
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,3 +5,4 @@ API Reference
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,7 @@
+API reference
+=============
+
+.. automodule:: kbatch_papermill
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,4 +1,4 @@
-API reference
+API Reference
 =============
 
 .. automodule:: kbatch_papermill

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,5 +3,5 @@ API Reference
 
 .. automodule:: kbatch_papermill
    :members:
-   :undoc-members:
    :show-inheritance:
+   :imported-members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,4 +5,3 @@ API Reference
    :members:
    :undoc-members:
    :show-inheritance:
-   :noindex:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,10 @@
 import os
 import tomli
 
-path = os.path.abspath("../pyproject.toml")
-with open(path, "rb") as f:
+from pathlib import Path
+
+pyproject_toml = Path(__file__).parents[1].resolve() / "pyproject.toml"
+with pyproject_toml.open("rb") as f:
     info = tomli.load(f)
 
 project = info["project"]["name"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,18 +13,8 @@ copyright = f"2024, {author}"
 
 extensions = ["myst_parser", "sphinx.ext.autodoc", "sphinx.ext.viewcode", "sphinx.ext.napoleon"]
 
-templates_path = ["_templates"]
+templates_path = []
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 html_theme = "sphinx_rtd_theme"
-html_static_path = ["_static"]
-
-
-# see: https://stackoverflow.com/a/18031024
-def remove_module_docstring(app, what, name, obj, options, lines):
-    if what == "module" and name == "kbatch_papermill":
-        del lines[:]
-
-
-def setup(app):
-    app.connect("autodoc-process-docstring", remove_module_docstring)
+html_static_path = []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@ release = info["project"]["version"]
 author = info["project"]["authors"][0]["name"]
 copyright = f"2024, {author}"
 
-extensions = ["myst_parser", "sphinx.ext.autodoc"]
+extensions = ["myst_parser", "sphinx.ext.autodoc", "sphinx.ext.viewcode"]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-import os
 import tomli
 
 from pathlib import Path
@@ -12,10 +11,20 @@ release = info["project"]["version"]
 author = info["project"]["authors"][0]["name"]
 copyright = f"2024, {author}"
 
-extensions = ["myst_parser", "sphinx.ext.autodoc", "sphinx.ext.viewcode"]
+extensions = ["myst_parser", "sphinx.ext.autodoc", "sphinx.ext.viewcode", "sphinx.ext.napoleon"]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
+
+
+# see: https://stackoverflow.com/a/18031024
+def remove_module_docstring(app, what, name, obj, options, lines):
+    if what == "module" and name == "kbatch_papermill":
+        del lines[:]
+
+
+def setup(app):
+    app.connect("autodoc-process-docstring", remove_module_docstring)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,19 @@
+import os
+import tomli
+
+path = os.path.abspath("../pyproject.toml")
+with open(path, "rb") as f:
+    info = tomli.load(f)
+
+project = info["project"]["name"]
+release = info["project"]["version"]
+author = info["project"]["authors"][0]["name"]
+copyright = f"2024, {author}"
+
+extensions = ["myst_parser", "sphinx.ext.autodoc"]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,5 +5,5 @@ Welcome to kbatch_papermill's documentation!
    :maxdepth: 2
    :caption: Contents:
 
-   readme.md
+   intro.md
    api

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,9 @@
+Welcome to kbatch_papermill's documentation!
+============================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   readme.md
+   api

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,0 +1,18 @@
+# Introduction
+
+Designed for [Destination-Earth GFTS](https://github.com/destination-earth/DestinE_ESA_GFTS), `kbatch_papermill` runs notebooks with [papermill] on Kubernetes via [kbatch].
+
+**DISCLAIMER:** the package does not currently target general use because the following assumptions, specific to GFTS deployments, are made:
+
+1. Default AWS credentials are set up via environment variables, and work.
+2. Jobs should always run with the same $JUPYTER_IMAGE as the submitting environment.
+3. $JUPYTER_IMAGE has `papermill`.
+4. We have read/write access to S3 for _both_ the code input directory and the output directory (completed job results).
+
+
+We also add some generic functionality to make a nicer Python API for kbatch, which should perhaps be upstreamed. See `_kbatch.py` for most of that.
+
+Besides, we overcome the size limit of the commonly used [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) approach by passing the code directory (currently to S3) instead.
+
+[papermill]: https://papermill.readthedocs.io
+[kbatch]: https://kbatch.readthedocs.io

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,4 @@
 sphinx
 sphinx-rtd-theme
-kbatch
-ipython
-ipywidgets
-tqdm
-s3fs
-papermill
 myst-parser
 tomli

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,10 @@
+sphinx
+sphinx-rtd-theme
+kbatch
+ipython
+ipywidgets
+tqdm
+s3fs
+papermill
+myst-parser
+tomli

--- a/kbatch_papermill/__init__.py
+++ b/kbatch_papermill/__init__.py
@@ -2,8 +2,7 @@
 Run notebooks via kbatch, store output in S3.
 """
 
-from ._kbatch import print_job_status, wait_for_jobs
-from ._papermill import kbatch_papermill
+from ._kbatch import * # noqa
+from ._papermill import * # noqa
 
 __version__ = "0.1.0.dev"
-__all__ = ["print_job_status", "wait_for_jobs", "kbatch_papermill"]

--- a/kbatch_papermill/__init__.py
+++ b/kbatch_papermill/__init__.py
@@ -1,7 +1,3 @@
-"""
-Run notebooks via kbatch, store output in s3
-"""
-
 from ._kbatch import print_job_status, wait_for_jobs
 from ._papermill import kbatch_papermill
 

--- a/kbatch_papermill/__init__.py
+++ b/kbatch_papermill/__init__.py
@@ -2,7 +2,8 @@
 Run notebooks via kbatch, store output in s3
 """
 
-from ._kbatch import *  # noqa
-from ._papermill import *  # noqa
+from ._kbatch import print_job_status, wait_for_jobs
+from ._papermill import kbatch_papermill
 
 __version__ = "0.1.0.dev"
+__all__ = ["print_job_status", "wait_for_jobs", "kbatch_papermill"]

--- a/kbatch_papermill/__init__.py
+++ b/kbatch_papermill/__init__.py
@@ -1,3 +1,7 @@
+"""
+Run notebooks via kbatch, store output in S3.
+"""
+
 from ._kbatch import print_job_status, wait_for_jobs
 from ._papermill import kbatch_papermill
 

--- a/kbatch_papermill/_kbatch.py
+++ b/kbatch_papermill/_kbatch.py
@@ -1,10 +1,10 @@
 """
-kbatch interface
-
-wraps kbatch for some nicer Python APIs
-
-Maybe some of this should be in kbatch
+Kbatch interface.
+It wraps kbatch with some nicer Python APIs.
+Maybe some of this should be in kbatch.
 """
+
+__all__ = ["print_job_status", "wait_for_jobs"]
 
 import time
 
@@ -21,14 +21,13 @@ def print_job_status():
 
 
 def wait_for_jobs(*job_names, stop_on_failure=True, failure_logs=True):
-    """Wait for one or more jobs by name.
+    """
+    Wait for one or more jobs by name.
 
-    :param job_names: Job names, default to all names.
-    :type job_names: list[str]
-    :param stop_on_failure: Whether to stop waiting on the first failure, default to True.
-    :type stop_on_failure: bool
-    :param failure_logs: Whether to print the logs of failed logs, default to True.
-    :type failure_logs: bool
+    Args:
+        job_names (list[str], optional): Job names. Defaults to all names.
+        stop_on_failure (bool, optional): Whether to stop waiting on the first failure. Defaults to True.
+        failure_logs (bool, optional): Whether to print the logs of failed jobs. Defaults to True.
     """
     if not job_names:
         job_names = [job["metadata"]["name"] for job in kbatch.list_jobs()["items"]]

--- a/kbatch_papermill/_kbatch.py
+++ b/kbatch_papermill/_kbatch.py
@@ -16,17 +16,19 @@ from tqdm.notebook import tqdm
 
 
 def print_job_status():
-    """Print status of all kbatch jobs as a nice table"""
+    """Print the status of all kbatch jobs as a nice table."""
     rich.print(kbatch._core.format_jobs(kbatch.list_jobs()))
 
 
 def wait_for_jobs(*job_names, stop_on_failure=True, failure_logs=True):
-    """Wait for one or more jobs by name
+    """Wait for one or more jobs by name.
 
-    Default: wait for all jobs.
-
-    args:
-        stop_on_failure (bool): whether to stop waiting on the first failure
+    :param job_names: Job names, default to all names.
+    :type job_names: list[str]
+    :param stop_on_failure: Whether to stop waiting on the first failure, default to True.
+    :type stop_on_failure: bool
+    :param failure_logs: Whether to print the logs of failed logs, default to True.
+    :type failure_logs: bool
     """
     if not job_names:
         job_names = [job["metadata"]["name"] for job in kbatch.list_jobs()["items"]]

--- a/kbatch_papermill/_papermill.py
+++ b/kbatch_papermill/_papermill.py
@@ -81,15 +81,23 @@ def kbatch_papermill(
     env: dict[str, str] | None = None,
     parameters: dict[str, Any] | None = None,
 ) -> str:
-    """Run a notebook with papermill and store the result in s3
+    """Run a notebook with papermill and store the result in s3.
 
-    Args:
-      notebook: path to notebook
-      s3_dest: s3 URL where the notebook should be stored (e.g. s3://bucket/path/to/notebook.ipynb)
-      job_name: name prefix for the kbatch job (default: papermill)
-      profile_name: name of the profile to run with (specifies resource requirements)
-      env: additional environment variables to set (AWS_ env will be set by default)
-      parameters: papermill parameters to pass
+    :param notebook: Path to notebook.
+    :type notebook: Path
+    :param s3_dest: s3 URL where the notebook should be stored (e.g. s3://bucket/path/to/notebook.ipynb).
+    :type s3_dest: str
+    :param job_name: Name prefix for the kbatch job, defaults to "papermill".
+    :type job_name: str
+    :param profile_name: Name of the profile to run with (specifies resource requirements), defaults to "default".
+    :type profile_name: str
+    :param env: Additional environment variables to set (other than "AWS\_" ones), default to None.
+    :type env: dict[str, str], optional
+    :param parameters: Papermill parameters to pass, default to None.
+    :type parameters: dict[str, Any], optional
+
+    :return: Name of the kbatch job.
+    :rtype: str
     """
 
     notebook = Path(notebook)

--- a/kbatch_papermill/_papermill.py
+++ b/kbatch_papermill/_papermill.py
@@ -1,6 +1,8 @@
 """
-Submit papermill jobs
+Submit papermill jobs.
 """
+
+__all__ = ["kbatch_papermill"]
 
 import os
 import shutil
@@ -81,23 +83,19 @@ def kbatch_papermill(
     env: dict[str, str] | None = None,
     parameters: dict[str, Any] | None = None,
 ) -> str:
-    """Run a notebook with papermill and store the result in s3.
+    """
+    Run a notebook with Papermill and store the result in S3.
 
-    :param notebook: Path to notebook.
-    :type notebook: Path
-    :param s3_dest: s3 URL where the notebook should be stored (e.g. s3://bucket/path/to/notebook.ipynb).
-    :type s3_dest: str
-    :param job_name: Name prefix for the kbatch job, defaults to "papermill".
-    :type job_name: str
-    :param profile_name: Name of the profile to run with (specifies resource requirements), defaults to "default".
-    :type profile_name: str
-    :param env: Additional environment variables to set (other than "AWS\_" ones), default to None.
-    :type env: dict[str, str], optional
-    :param parameters: Papermill parameters to pass, default to None.
-    :type parameters: dict[str, Any], optional
+    Args:
+        notebook (Path): Path to the notebook.
+        s3_dest (str): S3 URL where the notebook should be stored (e.g., s3://bucket/path/to/notebook.ipynb).
+        job_name (str, optional): Name prefix for the kbatch job. Defaults to "papermill".
+        profile_name (str, optional): Name of the profile to run with (specifies resource requirements). Defaults to "default".
+        env (dict[str, str], optional): Additional environment variables to set (other than "AWS\_" ones). Defaults to None.
+        parameters (dict[str, Any], optional): Papermill parameters to pass. Defaults to None.
 
-    :return: Name of the kbatch job.
-    :rtype: str
+    Returns:
+        str: Name of the kbatch job.
     """
 
     notebook = Path(notebook)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "kbatch-papermill"
 version = "0.1.0.dev"
-dynamic = ["readme"]
+dynamic = ["readme", "dependencies"]
 description = "KBatch Papermill: Run papermill in kbatch"
 authors = [
   { name = "Min RK", email = "benjaminrk@gmail.com" },


### PR DESCRIPTION
Hi,

I worked on improving the documentation of the package.
Precisely, I added a workflow that builds _ReadTheDocs_ documentation (with _Sphinx_) on push to `main` and I also slightly rephrased the current README file.
Rough description of the changes:

- GitHub workflow for building the documentation when pushing to `main`.
- Reformulated README.
- Changed ` __init__.py` to only expose public functions of the package.
- Changed the docstrings format of the documented functions (from Google to Sphinx).

I did not open an issue since I've already implemented a solution. The resulting documentation can be seen [here on my fork](https://quentinmaz.github.io/kbatch-papermill/).
The documentation is published as a GitHub Page.
I followed the common practise of pushing the files at the end of the workflow to the branch `gh-pages`, and configuring the GitHub Page to use the aforementioned branch. 

NB: I apologize for not having opened an issue to begin with, which could have been the opportunity to let everyone know that I was about to work on that as well as discussing the implementation. For instance, we could keep the Google docstrings format and use the napoleon Sphinx's extension to support them (see [here](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html)).